### PR TITLE
Revert "clean up annotation"

### DIFF
--- a/src/main/kotlin/one/oktw/galaxy/machine/chunkloader/data/ChunkLoader.kt
+++ b/src/main/kotlin/one/oktw/galaxy/machine/chunkloader/data/ChunkLoader.kt
@@ -2,11 +2,13 @@ package one.oktw.galaxy.machine.chunkloader.data
 
 import one.oktw.galaxy.galaxy.planet.data.Position
 import one.oktw.galaxy.item.type.Upgrade
+import org.bson.codecs.pojo.annotations.BsonCreator
+import org.bson.codecs.pojo.annotations.BsonProperty
 import java.util.*
 import kotlin.collections.ArrayList
 
-data class ChunkLoader(
-    val uuid: UUID = UUID.randomUUID(),
-    val position: Position,
-    var upgrade: ArrayList<Upgrade> = ArrayList()
+data class ChunkLoader @BsonCreator constructor(
+    @BsonProperty("uuid") val uuid: UUID = UUID.randomUUID(),
+    @BsonProperty("position") val position: Position,
+    @BsonProperty("upgrade") var upgrade: ArrayList<Upgrade> = ArrayList()
 )


### PR DESCRIPTION
Reverts OKTW-Network/Galaxy#142
炸了
```
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]: one.oktw.relocate.org.bson.codecs.configuration.CodecConfigurationException: An exception occurred when decoding using the AutomaticPojoCode
c.                                                                                                                                                                                                                                          Decoding into a 'ChunkLoader' failed with the following exception:
                                                                                                                                                               
Cannot find a public constructor for 'ChunkLoader'.                                                                                                                                                           
                                                                                                                                                                                                          
A custom Codec or PojoCodec may need to be explicitly configured and registered to handle this type.                                                                                                       
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.org.bson.codecs.pojo.AutomaticPojoCodec.decode(AutomaticPojoCodec.java:40)
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.com.mongodb.operation.CommandResultArrayCodec.decode(CommandResultArrayCodec.java:52)
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.com.mongodb.operation.CommandResultDocumentCodec.readValue(CommandResultDocumentCodec.java:60)
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.org.bson.codecs.BsonDocumentCodec.decode(BsonDocumentCodec.java:84)
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.org.bson.codecs.BsonDocumentCodec.decode(BsonDocumentCodec.java:41)
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.org.bson.codecs.configuration.LazyCodec.decode(LazyCodec.java:47)
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.org.bson.codecs.BsonDocumentCodec.readValue(BsonDocumentCodec.java:101)                                       
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.com.mongodb.operation.CommandResultDocumentCodec.readValue(CommandResultDocumentCodec.java:63)
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.org.bson.codecs.BsonDocumentCodec.decode(BsonDocumentCodec.java:84)           
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.org.bson.codecs.BsonDocumentCodec.decode(BsonDocumentCodec.java:41)         
[17:22:32] [CommonPool-worker-2/INFO] [STDERR]: [java.lang.ThreadGroup:uncaughtException:1052]:         at one.oktw.relocate.com.mongodb.internal.connection.ReplyMessage.<init>(ReplyMessage.java:48)                 
```