### PR TITLE
performance

### DIFF
--- a/src/main/kotlin/one/oktw/galaxy/block/event/Elevator.kt
+++ b/src/main/kotlin/one/oktw/galaxy/block/event/Elevator.kt
@@ -12,11 +12,10 @@ import org.spongepowered.api.entity.living.player.Player
 class Elevator {
     init {
         Keys.IS_SNEAKING.registerEvent(Player::class.java) {
-            if (it.endResult.successfulData.firstOrNull { it.key == Keys.IS_SNEAKING }?.get() != true) return@registerEvent
-
             val player = it.targetHolder as? Player ?: return@registerEvent
             val location = player.location.sub(0.0, 1.0, 0.0)
 
+            if (it.endResult.successfulData.firstOrNull { it.key == Keys.IS_SNEAKING }?.get() != true) return@registerEvent
             if (location.blockType != MOB_SPAWNER || location[DataBlockType.key].orElse(null) != ELEVATOR) return@registerEvent
 
             var target: Double? = null

--- a/src/main/kotlin/one/oktw/galaxy/item/event/ItemProtect.kt
+++ b/src/main/kotlin/one/oktw/galaxy/item/event/ItemProtect.kt
@@ -6,14 +6,14 @@ import one.oktw.galaxy.item.enums.ItemType.BUTTON
 import org.spongepowered.api.entity.living.player.Player
 import org.spongepowered.api.event.Listener
 import org.spongepowered.api.event.Order
-import org.spongepowered.api.event.filter.cause.First
+import org.spongepowered.api.event.filter.cause.Root
 import org.spongepowered.api.event.item.inventory.ClickInventoryEvent
 import org.spongepowered.api.event.item.inventory.DropItemEvent
 import org.spongepowered.api.item.inventory.InventoryArchetypes
 
 class ItemProtect {
     @Listener(order = Order.FIRST)
-    fun onDropItem(event: DropItemEvent.Pre, @First player: Player) {
+    fun onDropItem(event: DropItemEvent.Pre, @Root player: Player) {
         event.droppedItems.any { it[DataUUID.key].isPresent }.let(event::setCancelled)
     }
 

--- a/src/main/kotlin/one/oktw/galaxy/player/event/Viewer.kt
+++ b/src/main/kotlin/one/oktw/galaxy/player/event/Viewer.kt
@@ -171,11 +171,7 @@ class Viewer {
 
     @Listener(order = Order.FIRST)
     fun onCollideEntity(event: CollideEntityEvent) {
-        if (event.cause.first(Player::class.java).orElse(null)?.let { isViewer(it.uniqueId) } == true) {
-            event.isCancelled = true
-        } else {
-            event.entities.removeIf { it is Player && isViewer(it.uniqueId) }
-        }
+        event.isCancelled = event.cause.first(Player::class.java).orElse(null)?.let { isViewer(it.uniqueId) } == true
     }
 
     @Listener(order = Order.FIRST)


### PR DESCRIPTION
刪除不必要的判定以改善效能

* 玩家被推擠是客戶端判定，在伺服器端取消沒有意義
* 先判斷是否為玩家再檢查是否蹲下，這原本應該是SpongeAPI該處理的
* 只過濾直接由玩家觸發的物品掉落事件，SpongeAPI的cause會把玩家生的生物也包含玩家本身