### PR TITLE
Only keep load one chunk at spawn point

### DIFF
--- a/src/main/java/one/oktw/galaxy/mixin/tweak/MixinOneSpawnChunk_MinecraftServer.java
+++ b/src/main/java/one/oktw/galaxy/mixin/tweak/MixinOneSpawnChunk_MinecraftServer.java
@@ -1,0 +1,37 @@
+/*
+ * OKTW Galaxy Project
+ * Copyright (C) 2018-2020
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package one.oktw.galaxy.mixin.tweak;
+
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+
+@Mixin(MinecraftServer.class)
+public class MixinOneSpawnChunk_MinecraftServer {
+    @ModifyConstant(method = "prepareStartRegion", constant = @Constant(intValue = 11))
+    private int onlyForceLoadOneChunk(int radius) {
+        return 1;
+    }
+
+    @ModifyConstant(method = "prepareStartRegion", constant = @Constant(intValue = 441))
+    private int skipChunkPreGen(int loadedChunks) {
+        return 1;
+    }
+}

--- a/src/main/java/one/oktw/galaxy/mixin/tweak/MixinOneSpawnChunk_ServerWorld.java
+++ b/src/main/java/one/oktw/galaxy/mixin/tweak/MixinOneSpawnChunk_ServerWorld.java
@@ -1,6 +1,6 @@
 /*
  * OKTW Galaxy Project
- * Copyright (C) 2018-2019
+ * Copyright (C) 2018-2020
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -18,16 +18,15 @@
 
 package one.oktw.galaxy.mixin.tweak;
 
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.world.ServerChunkManager;
+import net.minecraft.server.world.ServerWorld;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
-@Mixin(MinecraftServer.class)
-public class MixinPreGenSpawn_MinecraftServer {
-    @Redirect(method = "prepareStartRegion", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ServerChunkManager;getTotalChunksLoadedCount()I"))
-    private <T> int skipLoadSpawn(ServerChunkManager serverChunkManager) {
-        return 441;
+@Mixin(ServerWorld.class)
+public class MixinOneSpawnChunk_ServerWorld {
+    @ModifyConstant(method = "setSpawnPos", constant = @Constant(intValue = 11))
+    private int onlyForceLoadOneChunk(int radius) {
+        return 1;
     }
 }

--- a/src/main/resources/tweak.mixin.json
+++ b/src/main/resources/tweak.mixin.json
@@ -3,7 +3,8 @@
   "package": "one.oktw.galaxy.mixin.tweak",
   "compatibilityLevel": "JAVA_14",
   "mixins": [
-    "MixinPreGenSpawn_MinecraftServer",
+    "MixinOneSpawnChunk_MinecraftServer",
+    "MixinOneSpawnChunk_ServerWorld",
     "MixinRCON_RconBase",
     "MixinRCON_RconClient"
   ],


### PR DESCRIPTION
原版Minecraft將重生點周圍半徑11 Chunk保持載入
為了加快星系載入速度與減少資源佔用，改成只載入1 Chunk