### PR TITLE
Fix hand events

### DIFF
--- a/src/main/kotlin/one/oktw/galaxy/item/event/Wrench.kt
+++ b/src/main/kotlin/one/oktw/galaxy/item/event/Wrench.kt
@@ -1,6 +1,6 @@
 /*
  * OKTW Galaxy Project
- * Copyright (C) 2018-2023
+ * Copyright (C) 2018-2024
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -79,6 +79,7 @@ class Wrench {
             startDirection[player] = blockPos to direction
 
             blockEntity.facing = if (next == -1 || next > allowedFacing.lastIndex) allowedFacing.first() else allowedFacing[next]
+            return true
         }
 
         // Check destructible

--- a/src/main/kotlin/one/oktw/galaxy/item/event/Wrench.kt
+++ b/src/main/kotlin/one/oktw/galaxy/item/event/Wrench.kt
@@ -214,7 +214,8 @@ class Wrench {
 
         world.setBlockState(blockPos, newState)
         world.updateNeighbor(newState, blockPos, newState.block, blockPos, true)
-        Block.postProcessState(newState, world, blockPos).let { if (!it.isAir) world.setBlockState(blockPos, it, 2) }
+        // Workaround disable state update for bell
+        Block.postProcessState(newState, world, blockPos).let { if (!it.isAir && it.block != BELL) world.setBlockState(blockPos, it, 2) }
 
         return true
     }

--- a/src/main/kotlin/one/oktw/galaxy/player/Harvest.kt
+++ b/src/main/kotlin/one/oktw/galaxy/player/Harvest.kt
@@ -1,6 +1,6 @@
 /*
  * OKTW Galaxy Project
- * Copyright (C) 2018-2023
+ * Copyright (C) 2018-2024
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -44,7 +44,11 @@ class Harvest {
         val blockPos = event.packet.blockHitResult.blockPos
         val blockState = world.getBlockState(blockPos)
 
-        if (event.packet.hand == Hand.MAIN_HAND && !player.isSneaking && isMature(world, blockPos, blockState)) {
+        if (
+            event.packet.hand == Hand.MAIN_HAND &&
+            (!player.isSneaking || (player.mainHandStack.isEmpty && player.offHandStack.isEmpty)) &&
+            isMature(world, blockPos, blockState)
+        ) {
             event.cancel = true
             val block = blockState.block
             val ageProperties = when (block) {


### PR DESCRIPTION
## Changes
- fix player should be able to harvest when hands are empty whenever player is sneaking
- fix hand not swing when spinning custom block
- Workaround disable post state update for bell

## Related
- fixes #437 
- fixes #379 
