### PR TITLE
1.21.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,10 +11,10 @@ plugins {
 val version = "0.0.1"
 val group = "one.oktw"
 
-val minecraftVersion = "1.21.9"
-val mappingVersion = "1.21.9+build.1"
+val minecraftVersion = "1.21.10"
+val mappingVersion = "1.21.10+build.1"
 val fabricLoaderVersion = "0.17.2"
-val fabricAPIVersion = "0.133.14+1.21.9"
+val fabricAPIVersion = "0.134.1+1.21.10"
 val galaxyLibVersion = "f4e1b25"
 
 repositories {


### PR DESCRIPTION
# Changes

- Bump the Minecraft version to 1.21.10.
  - Update mods
  
# Related
- https://github.com/OKTW-Network/Galaxy-proxy/pull/312
- https://github.com/OKTW-Network/Docker-Galaxy/pull/52
